### PR TITLE
fix!: Re-structured how uncollation is done to make more efficient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,24 @@
-[package]
-name = "uncollate"
-version = "0.1.0"
+[workspace]
+members = ["macro"]
+
+[workspace.package]
 edition = "2024"
+version = "0.1.0"
 repository = "https://github.com/wdjcodes/uncollate"
 authors = ["wdjcodes"]
-description = "Uncollate array of structs into arrays of field"
 license = "MIT"
 
+[package]
+name = "uncollate"
+description = "Uncollate array of structs into arrays of field"
+edition.workspace = true
+version.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+
 [lib]
-proc-macro = true
+path = "./src/lib.rs"
 
 [dependencies]
-proc-macro2 = "1.0.106"
-quote = "1.0.44"
-syn = "2.0.116"
+uncollate_macro = { path = "macro" }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,7 +11,8 @@ fn main(){
         Basic{ a: true, b: 12 },
         Basic{ a: false, b: 43 }
     ];
-    let bs: &[Basic] = &basics;
-    println!("{:?}", basics.uncoll_a());
-    println!("{:?}", bs.uncoll_b());
+    let uc = basics.uncollate();
+
+    println!("{:?}", uc.a());
+    println!("{:?}", uc.b());
 }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "uncollate_macro"
+description = "macro implementation for the uncollate crate"
+edition.workspace = true
+version.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.106"
+quote = "1.0.44"
+syn = "2.0.116"

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,0 +1,76 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, Error, parse_macro_input, spanned::Spanned};
+
+
+/// This macro allows splitting a vector of structs into a struct of vectors over each field.
+/// This is accomplished in a few steps.
+/// 
+/// 1. Creates an `UncollatedT` type which has a field corresponding to each field of `T` with type
+///    `Vec<F>` and `F` is the type of field in `T`.
+/// 2. Impls `Collated` for type `T`. The `Collated` trait is used to add the fields of a single
+///    instance of `T` to corresponding vectors in a provided UncollatedT struct instance.
+/// 3. The `Uncollate` trait is then able to be used on any type that impls `IntoIter<Item = T>`
+///    which provides the `uncollate` method to get an `UncollatedT`
+/// 
+/// 
+///
+/// # Examples
+///
+/// ```
+/// use uncollate::derive_uncollate;
+///
+/// #[derive(Uncollate)]
+/// struct Dog {
+///     name: String,
+///     breed: String
+/// }
+/// 
+/// let dogs = vec![
+///     Dog {name: "Bandit".to_string(), breed: "Beagle".to_string()}, 
+///     Dog {name: "Scout".to_string(), breed: "Pug".to_string()}
+/// ];
+/// 
+/// let uncol_dogs = dogs.uncollate();
+/// 
+/// assert_eq!(uncol_dogs.name(), vec!["Bandit".to_string(), "Scout".to_string()]);
+/// assert_eq!(uncol_dogs.breed(), vec!["Beagle".to_string(), "Pug".to_string()]);
+/// ```
+#[proc_macro_derive(Uncollate)]
+pub fn derive_uncollate(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let data = if let Data::Struct(data) = input.data {
+        data
+    } else {
+        return Error::new(input.span(), "Uncollate can only be derived for structs").into_compile_error().into();
+    };
+    let struct_name = &input.ident;
+    let uncollated_name = format_ident!("Uncollated{}", struct_name);
+    let field_names: Vec<_> = data.fields.iter().filter_map(|f| f.ident.as_ref()).collect();
+    // let function_names: Vec<_> = field_names.iter().map(|f| format_ident!("uncoll_{}", f)).collect();
+    let field_types: Vec<_> = data.fields.iter().map(|f| &f.ty).collect();
+    let uncollated = quote! {
+        #[derive(Default)]
+        pub struct #uncollated_name {
+            #(#field_names: std::vec::Vec<#field_types>),*
+        }
+
+        impl #uncollated_name {
+            #(pub fn #field_names(&self) -> &Vec<#field_types>{
+                &self.#field_names
+            })*
+        }
+
+        impl uncollate::Uncollated for #uncollated_name{}
+
+        impl uncollate::Collated<#uncollated_name> for #struct_name {
+            fn uncollate_one(self, uncollated: &mut #uncollated_name) {
+                #(uncollated.#field_names.push(self.#field_names);)*
+            }
+        }
+    };
+    quote! {
+        #uncollated
+    }.into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,64 +1,20 @@
-use proc_macro::TokenStream;
-use quote::{format_ident, quote};
-use syn::{Data, DeriveInput, Error, parse_macro_input, spanned::Spanned};
+pub use uncollate_macro::Uncollate;
+pub trait Uncollate<T> {
+    fn uncollate(self) -> T;
+}
 
+pub trait Collated<T: Uncollated> {
+    fn uncollate_one(self, uncollated: &mut T);
+}
 
-/// Derives the `UncollateT` trait from struct `T`.
-/// 
-/// 
-/// For each field `T.field: F` `UncollateT` provides `fn uncoll_field(&self) -> Vec<F>`.
-/// `UncollateT` is implemented for objects that are sequences of T aka `impl Deref<Target = [T]>`.
-/// 
-/// 
-///
-/// # Examples
-///
-/// ```
-/// use uncollate::derive_uncollate;
-///
-/// #[derive(Uncollate)]
-/// struct Dog {
-///     name: String,
-///     breed: String
-/// }
-/// 
-/// let dogs = vec![
-///     Dog {name: "Bandit".to_string(), breed: "Beagle".to_string()}, 
-///     Dog {name: "Scout".to_string(), breed: "Pug".to_string()}
-/// ];
-/// 
-/// assert_eq!(dogs.uncoll_name(), vec!["Bandit".to_string(), "Scout".to_string()]);
-/// assert_eq!(dogs.uncoll_breed(), vec!["Beagle".to_string(), "Pug".to_string()]);
-/// ```
-#[proc_macro_derive(Uncollate)]
-pub fn derive_uncollate(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+pub trait Uncollated: Default {}
 
-    let data = if let Data::Struct(data) = input.data {
-        data
-    } else {
-        return Error::new(input.span(), "Uncollate can only be derived for structs").into_compile_error().into();
-    };
-    let struct_name = &input.ident;
-    let trait_name = format_ident!("Uncollate{}", struct_name);
-    let field_names: Vec<_> = data.fields.iter().filter_map(|f| f.ident.as_ref()).collect();
-    let function_names: Vec<_> = field_names.iter().map(|f| format_ident!("uncoll_{}", f)).collect();
-    let field_types: Vec<_> = data.fields.iter().map(|f| &f.ty).collect();
-    let uncollate = quote! {
-        pub trait #trait_name {
-            #(fn #function_names(&self) -> std::vec::Vec<#field_types>; )*
+impl<U: Uncollated, C: Collated<U>, T: IntoIterator<Item = C>> Uncollate<U> for T {
+    fn uncollate(self) -> U {
+        let mut uncollated: U = Default::default();
+        for collated in self {
+            collated.uncollate_one(&mut uncollated);
         }
-    };
-
-    let impls = quote! {
-        impl<T: std::ops::Deref<Target = [#struct_name]>> #trait_name for T {
-            #(fn #function_names(&self) -> std::vec::Vec<#field_types> {
-                self.iter().map(|f| f.#field_names).collect()
-            })*
-        } 
-    };
-    quote! {
-        #uncollate
-        #impls
-    }.into()
+        uncollated
+    }
 }

--- a/tests/option_string.rs
+++ b/tests/option_string.rs
@@ -1,0 +1,21 @@
+use uncollate::Uncollate;
+
+#[derive(Uncollate)]
+pub struct Os {
+    opt: Option<String>
+}
+
+#[test]
+fn uncollate_option_string() {
+    let opts = vec![
+        Os { opt: Some("apple".into())},
+        Os { opt: None },
+        Os { opt: Some("banana".into())}
+    ];
+
+    let uncol = opts.uncollate();
+
+    assert_eq!(uncol.opt[0], Some("apple".into()));
+    assert_eq!(uncol.opt[1], None);
+    assert_eq!(uncol.opt[2], Some("banana".into()));
+}


### PR DESCRIPTION
Uncollate now consumes the original buffer and creates a new struct instead of generating dynamic traits.